### PR TITLE
Implement basic Cards Against Humanity game

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
+import random
+import json
+from typing import Dict, List, Optional
 
 app = FastAPI()
 app.add_middleware(
@@ -11,23 +14,151 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Sample cards for demonstration. A real implementation would use a much larger deck.
+BLACK_CARDS = [
+    "Why can't I sleep at night?",
+    "I got 99 problems but ____ ain't one.",
+    "What's that smell?",
+]
+
+WHITE_CARDS = [
+    "A bag of magic beans.",
+    "A subscription to Men's Fitness.",
+    "An endless stream of diarrhea.",
+    "Eating the last known bison.",
+    "My ex-wife.",
+    "A pyramid of severed heads.",
+    "The miracle of childbirth.",
+    "Fifty milligrams of Zoloft daily.",
+    "A falcon with a cap on its head.",
+    "The Kool-Aid Man.",
+]
+
+class Player:
+    def __init__(self, websocket: WebSocket, name: str):
+        self.websocket = websocket
+        self.name = name
+        self.hand: List[str] = []
+        self.score = 0
+
+class Game:
+    def __init__(self):
+        self.players: List[Player] = []
+        self.judge_index = 0
+        self.black_deck: List[str] = []
+        self.white_deck: List[str] = []
+        self.current_black: Optional[str] = None
+        self.submissions: Dict[str, str] = {}
+        self.started = False
+
+    def add_player(self, player: Player):
+        self.players.append(player)
+
+    def remove_player(self, player: Player):
+        self.players = [p for p in self.players if p != player]
+        if self.judge_index >= len(self.players):
+            self.judge_index = 0
+
+    def start(self):
+        self.black_deck = random.sample(BLACK_CARDS, len(BLACK_CARDS))
+        self.white_deck = random.sample(WHITE_CARDS, len(WHITE_CARDS))
+        self.started = True
+        self.deal_hands()
+        self.next_round()
+
+    def deal_hands(self):
+        for player in self.players:
+            while len(player.hand) < 7 and self.white_deck:
+                player.hand.append(self.white_deck.pop())
+
+    def next_round(self):
+        self.submissions.clear()
+        if not self.black_deck:
+            self.started = False
+            self.current_black = None
+            return
+        self.current_black = self.black_deck.pop()
+        self.judge_index = self.judge_index % len(self.players)
+        self.deal_hands()
+
+    def judge(self) -> Optional[Player]:
+        if not self.players:
+            return None
+        return self.players[self.judge_index % len(self.players)]
+
+    def rotate_judge(self):
+        self.judge_index = (self.judge_index + 1) % len(self.players)
+
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: dict[str, set[WebSocket]] = {}
+        self.games: Dict[str, Game] = {}
+        self.player_map: Dict[WebSocket, Player] = {}
 
     async def connect(self, room: str, websocket: WebSocket):
         await websocket.accept()
-        self.active_connections.setdefault(room, set()).add(websocket)
+        self.games.setdefault(room, Game())
 
     def disconnect(self, room: str, websocket: WebSocket):
-        if room in self.active_connections:
-            self.active_connections[room].discard(websocket)
-            if not self.active_connections[room]:
-                del self.active_connections[room]
+        game = self.games.get(room)
+        player = self.player_map.get(websocket)
+        if game and player:
+            game.remove_player(player)
+            del self.player_map[websocket]
+            if not game.players:
+                del self.games[room]
 
-    async def broadcast(self, room: str, message: str):
-        for connection in list(self.active_connections.get(room, [])):
-            await connection.send_text(message)
+    def add_player(self, room: str, websocket: WebSocket, name: str) -> Player:
+        game = self.games[room]
+        player = Player(websocket, name)
+        game.add_player(player)
+        self.player_map[websocket] = player
+        return player
+
+    async def send_state(self, room: str):
+        game = self.games.get(room)
+        if not game:
+            return
+        for player in game.players:
+            state = {
+                "type": "state",
+                "players": [
+                    {"name": p.name, "score": p.score} for p in game.players
+                ],
+                "judge": game.judge().name if game.started else None,
+                "black_card": game.current_black,
+                "hand": player.hand,
+                "started": game.started,
+            }
+            if player == game.judge() and game.submissions:
+                state["submissions"] = game.submissions
+            await player.websocket.send_text(json.dumps(state))
+
+    async def handle_message(self, room: str, websocket: WebSocket, data: dict):
+        game = self.games[room]
+        player = self.player_map[websocket]
+        action = data.get("action")
+        if action == "start_game":
+            if not game.started:
+                game.start()
+                await self.send_state(room)
+        elif action == "play_card" and game.started:
+            idx = data.get("index")
+            if idx is None or idx >= len(player.hand):
+                return
+            card = player.hand.pop(idx)
+            game.submissions[player.name] = card
+            await self.send_state(room)
+            if len(game.submissions) >= len(game.players) - 1:
+                # all non-judge submitted
+                await self.send_state(room)
+        elif action == "choose_winner" and player == game.judge():
+            winner_name = data.get("player")
+            winner = next((p for p in game.players if p.name == winner_name), None)
+            if winner:
+                winner.score += 1
+            game.rotate_judge()
+            game.next_round()
+            await self.send_state(room)
 
 manager = ConnectionManager()
 
@@ -35,11 +166,21 @@ manager = ConnectionManager()
 async def websocket_endpoint(websocket: WebSocket, room: str):
     await manager.connect(room, websocket)
     try:
+        join_data = await websocket.receive_text()
+        data = json.loads(join_data)
+        if data.get("action") != "join":
+            await websocket.close()
+            return
+        name = data.get("name", "Anonymous")
+        player = manager.add_player(room, websocket, name)
+        await manager.send_state(room)
         while True:
-            data = await websocket.receive_text()
-            await manager.broadcast(room, data)
+            message = await websocket.receive_text()
+            data = json.loads(message)
+            await manager.handle_message(room, websocket, data)
     except WebSocketDisconnect:
         manager.disconnect(room, websocket)
+        await manager.send_state(room)
 
 if __name__ == "__main__":
     uvicorn.run("app:app", host="0.0.0.0", port=5001, reload=True)

--- a/frontend/components/Homepage.tsx
+++ b/frontend/components/Homepage.tsx
@@ -1,19 +1,37 @@
-import React from "react";
+import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 
 const Homepage = () => {
   const router = useRouter();
 
+  const [room, setRoom] = useState("");
+
   const createRoom = () => {
-    // Logic to create a room and navigate to the room page
-    const roomId = Math.random().toString(36).substring(2, 15); // Generate a random room ID
+    const roomId = Math.random().toString(36).substring(2, 15);
     router.push(`/rooms/${roomId}`);
+  };
+
+  const joinRoom = () => {
+    if (room.trim()) {
+      router.push(`/rooms/${room}`);
+    }
   };
 
   return (
     <div>
       <h1>Welcome to Cards Against Humanity</h1>
-      <button onClick={createRoom}>Create Room</button>
+      <div>
+        <button onClick={createRoom}>Create Room</button>
+      </div>
+      <div>
+        <input
+          type="text"
+          placeholder="Room ID"
+          value={room}
+          onChange={(e) => setRoom(e.target.value)}
+        />
+        <button onClick={joinRoom}>Join Room</button>
+      </div>
     </div>
   );
 };

--- a/frontend/pages/rooms/[room_id].tsx
+++ b/frontend/pages/rooms/[room_id].tsx
@@ -3,52 +3,122 @@
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 
+interface Player {
+  name: string;
+  score: number;
+}
+
+interface GameState {
+  type: string;
+  players: Player[];
+  judge: string | null;
+  black_card: string | null;
+  hand: string[];
+  started: boolean;
+  submissions?: Record<string, string>;
+}
+
 const Room = () => {
   const router = useRouter();
   const { room_id } = router.query;
 
-  const [message, setMessage] = useState("");
-  const [messages, setMessages] = useState<string[]>([]);
+  const [name, setName] = useState("");
+  const [joined, setJoined] = useState(false);
+  const [state, setState] = useState<GameState | null>(null);
+  const [played, setPlayed] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
 
+  const send = (data: any) => {
+    socketRef.current?.send(JSON.stringify(data));
+  };
+
   useEffect(() => {
-    if (room_id) {
+    if (room_id && !socketRef.current) {
       const ws = new WebSocket(`ws://localhost:5001/ws/${room_id}`);
       socketRef.current = ws;
-
       ws.onmessage = (event) => {
-        setMessages((prev) => [...prev, event.data]);
+        const data = JSON.parse(event.data) as GameState;
+        if (data.type === "state") {
+          setState(data);
+          setPlayed(false);
+        }
       };
-
-      return () => {
-        ws.close();
+      ws.onclose = () => {
+        socketRef.current = null;
       };
     }
   }, [room_id]);
 
-  const sendMessage = () => {
-    if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
-      socketRef.current.send(message);
-      setMessage("");
-    }
+  const join = () => {
+    send({ action: "join", name });
+    setJoined(true);
+  };
+
+  const startGame = () => send({ action: "start_game" });
+
+  const playCard = (idx: number) => {
+    send({ action: "play_card", index: idx });
+    setPlayed(true);
+  };
+
+  const chooseWinner = (player: string) => {
+    send({ action: "choose_winner", player });
   };
 
   return (
-    <div className="App">
-      <h1>Chat Application</h1>
-      <div className="chat-box">
-        {messages.map((msg, index) => (
-          <div key={index} className="message">
-            {msg}
-          </div>
-        ))}
-      </div>
-      <input
-        type="text"
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-      />
-      <button onClick={sendMessage}>Send</button>
+    <div>
+      {!joined ? (
+        <div>
+          <h2>Join Room {room_id}</h2>
+          <input
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <button onClick={join}>Join</button>
+        </div>
+      ) : (
+        <div>
+          <h2>Players</h2>
+          <ul>
+            {state?.players.map((p) => (
+              <li key={p.name}>
+                {p.name} - {p.score}
+              </li>
+            ))}
+          </ul>
+          {state?.judge && <p>Judge: {state.judge}</p>}
+          {state?.black_card && <h3>{state.black_card}</h3>}
+          {state && state.hand && (
+            <div>
+              <h4>Your hand</h4>
+              {state.hand.map((card, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => playCard(idx)}
+                  disabled={played || state.judge === name}
+                >
+                  {card}
+                </button>
+              ))}
+            </div>
+          )}
+          {state?.submissions && state.judge === name && (
+            <div>
+              <h4>Pick the winner</h4>
+              {Object.entries(state.submissions).map(([player, card]) => (
+                <button key={player} onClick={() => chooseWinner(player)}>
+                  {card}
+                </button>
+              ))}
+            </div>
+          )}
+          {!state?.started && (
+            <button onClick={startGame}>Start Game</button>
+          )}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add backend game logic to manage rooms and rounds
- allow creating or joining rooms on the homepage
- implement a game UI for each room

## Testing
- `python -m py_compile app.py`
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68432e9cae7c8324b402d93342637ac6